### PR TITLE
Update SimpleViewComponent.cs

### DIFF
--- a/Module01/Chapter04/Chapter4/src/Chapter4/ViewComponents/SimpleViewComponent.cs
+++ b/Module01/Chapter04/Chapter4/src/Chapter4/ViewComponents/SimpleViewComponent.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNet.Mvc;
 
 namespace Chapter4.ViewComponents
 {
-    public class SimpleViewComponent :ViewComponent
+    public class Simple :ViewComponent
     {        
         public IViewComponentResult Invoke()
         {


### PR DESCRIPTION
I tried this on with ASP.Net Core 5, But it gives me this error 
" A view component named 'Simple' could not be found. A view component must be a public non-abstract class, not contain any generic parameters, and either be decorated with 'View Component Attribute' or have a class name ending with the 'ViewComponent' suffix. A view component must not be decorated with 'NonViewComponent Attribute'." 
found the solution so I decided to update the code 
Class Name should be only name without  ViewComponent suffix and in Default.cshtml  @component invoke("Simple") into  @component invokeAsync(nameof(Simple))